### PR TITLE
Fixed a bug: connections weren't actually removed

### DIFF
--- a/PixelGameEngine/BiggerProjects/Networking/Parts3&4/olcPGEX_Network.h
+++ b/PixelGameEngine/BiggerProjects/Networking/Parts3&4/olcPGEX_Network.h
@@ -51,7 +51,7 @@
 
 	Author
 	~~~~~~
-	David Barr, aka javidx9, ©OneLoneCoder 2019, 2020, 2021
+	David Barr, aka javidx9, Â©OneLoneCoder 2019, 2020, 2021
 
 */
 
@@ -922,12 +922,12 @@ namespace olc
 					// be tracking it somehow
 					OnClientDisconnect(client);
 
-					// Off you go now, bye bye!
-					client.reset();
-
 					// Then physically remove it from the container
 					m_deqConnections.erase(
 						std::remove(m_deqConnections.begin(), m_deqConnections.end(), client), m_deqConnections.end());
+
+					// Off you go now, bye bye!
+					client.reset();
 				}
 			}
 			


### PR DESCRIPTION
In server_interface::MessageClient(client):
In the branch where "client" was found to be not connected (else on line 918): Line 926, "client.reset()," is before line 929, "erase client from m_deqConnections." This means "client" evaluates to nullptr, whereas the shared_ptr in m_deqConnections has not been reset. Nothing is removed from the container.

Fix:  I swapped the two lines.

Found by / reproducable by:
My implementation had a function "DisconnectClient" which copied the logic in this else block. Another function, "DisconnectAll," simply said:
while (!m_deqConnections.empty()) DisconnectClient(m_deqConnections.front()); Infinite loop.

I don't know why the file viewer says I changed the Author line. I didn't.