### PR TITLE
Fix shunting yard

### DIFF
--- a/SimplyCode/OneLoneCoder_ShuntingYardAlgo.cpp
+++ b/SimplyCode/OneLoneCoder_ShuntingYardAlgo.cpp
@@ -71,9 +71,9 @@ int main()
 	};
 
 	std::unordered_map<char, sOperator> mapOps;
-	mapOps['/'] = { 4, 2 };
-	mapOps['*'] = { 3, 2 };
-	mapOps['+'] = { 2, 2 };
+	mapOps['/'] = { 2, 2 };
+	mapOps['*'] = { 2, 2 };
+	mapOps['+'] = { 1, 2 };
 	mapOps['-'] = { 1, 2 };
 
 	std::string sExpression = "-((1+2)/((6*-7)+(7*-4)/2)-3)";


### PR DESCRIPTION
I've set division and multiplication to the same precedence (aka 2) and addition and subtraction to 1.

See #84.

Still not convinced?

Try to evaluate this (with the shunting yard code):
1+2*4-3+5/6